### PR TITLE
Fix spawn error on Windows

### DIFF
--- a/scripts/offline-build.mjs
+++ b/scripts/offline-build.mjs
@@ -94,7 +94,9 @@ async function downloadAssets(articles) {
 async function runGenerate() {
   await new Promise((resolve, reject) => {
     const npxCmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-    const child = spawn(npxCmd, ['nuxi', 'generate'], { stdio: 'inherit' });
+    const options = { stdio: 'inherit' };
+    if (process.platform === 'win32') options.shell = true;
+    const child = spawn(npxCmd, ['nuxi', 'generate'], options);
     child.on('close', code => {
       if (code !== 0) reject(new Error('nuxt generate failed'));
       else resolve();


### PR DESCRIPTION
## Summary
- handle Windows child process spawning by setting `shell` when needed

## Testing
- `npm test` *(fails: Missing script)*
- `DATO_CMS_TOKEN=123 npm run offline-build` *(fails: fetch ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_685bbef941f0832297d2d786782fbb7f