### PR TITLE
Fix offline build provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This command downloads all image assets referenced by the GraphQL queries into
  `.env` file and exits if `DATO_CMS_TOKEN` is missing. On Windows the script
  automatically spawns `npx.cmd`, so ensure Node.js is installed and available on
  your `PATH`. During this build the `OFFLINE_BUILD` environment variable is set
- so Nuxt uses the `static` image provider instead of `ipx`, which avoids Windows
+ so Nuxt uses the `ipxStatic` image provider instead of `ipx`, which avoids Windows
  path issues when generating image assets.
 
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,9 +9,9 @@ export default defineNuxtConfig({
   css: ["~/assets/css/main.css"],
   modules: ["@nuxt/image"],
   image: {
-    // Use the IPX provider normally, but switch to the "static" provider
+    // Use the IPX provider normally, but switch to the "ipxStatic" provider
     // when performing an offline build to avoid Windows path issues
-    provider: process.env.OFFLINE_BUILD ? "static" : "ipx",
+    provider: process.env.OFFLINE_BUILD ? "ipxStatic" : "ipx",
     domains: ["www.datocms-assets.com"],
   },
   app: {


### PR DESCRIPTION
## Summary
- update instructions to note using `ipxStatic` provider
- use `ipxStatic` during offline build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68601bff94848322955b2b78430bcf2c